### PR TITLE
feat(find-git-uri): adds error handler to git clone step

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -172,8 +172,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
 version = "1.24.1"
 
 [metadata]
-content-hash = "6b379b53b789f5ee3286e330d5d2ff10986427978791177d8aea2c0cb88a2ca7"
-python-versions = "^3.6"
+content-hash = "0241e08c02de261e207db1022b62f5e29438805b67cb43d120e9c538291fc6b4"
+python-versions = "^3.7"
 
 [metadata.hashes]
 atomicwrites = ["0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0", "ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Tyler M. Kontra"]
 license = "GPL-3.0"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 "ruamel.yaml" = "^0.15.81"
 requests = "^2.21"
 requests_cache = "^0.4.13"

--- a/src/app.py
+++ b/src/app.py
@@ -8,7 +8,7 @@ from .config import Config
 
 def main():
     apa = APA()
-    apa._projects = apa._projects[:7]
+    apa._projects = apa._projects[:10]
     print(f"{len(apa)} modules to parse.")
     project_globs = GitLibrary(apa).pyglob
     py_file_count = sum(len(list(p.glob)) for p in project_globs) 

--- a/src/ast_analyzer.py
+++ b/src/ast_analyzer.py
@@ -1,6 +1,5 @@
 import ast
 import itertools
-import copy
 from collections import namedtuple, Counter
 from src.config import Config
 

--- a/src/ast_analyzer.py
+++ b/src/ast_analyzer.py
@@ -1,11 +1,15 @@
 import ast
 import itertools
-from collections import namedtuple, Counter
+from dataclasses import dataclass
+from collections import Counter
 from src.config import Config
 
 logger = Config.getLogger("ast_analyzer")
 
-Import = namedtuple("Import", ["module"])
+@dataclass(frozen=True, eq=True)
+class Import:
+    module: str
+    
 
 def get_imports(name: str, glob: list):
     logger.info(f"Getting imports in {name}")
@@ -50,8 +54,11 @@ def _load_file(path):
         try:
             return ast.parse(fh.read(), path)
         except SyntaxError:
-            logger.error(f"File {path} using invalid syntax could not be parsed")
+            logger.error("File %s using invalid syntax could not be parsed", path)
             return None
+        except UnicodeDecodeError as e:
+            logger.error("File %s contains invalid Unicode: %s", path, e)
+            return None  
     
 def _parse_root(root):
     for node in ast.iter_child_nodes(root):

--- a/src/git.py
+++ b/src/git.py
@@ -40,7 +40,7 @@ class GitProject:
             logger.debug("Cloning repo at %s to %s",  self.url,  self.dest_path)
             try:
                 # try cloning from the given repo_url
-                git.Repo.clone_from(self.url,  self.dest_path,  branch="master")
+                self._clone_repo(self.url, self.dest_path)
                 cloned = True
             except git.exc.GitCommandError as e:
                 # if repo_url failed, find git:// URIs in the page
@@ -49,7 +49,7 @@ class GitProject:
                 while cloned == False:
                     for uri in git_uris:
                         try:
-                            git.Repo.clone_from(uri, self.dest_path, branch="master")
+                            self._clone_repo(uri, self.dest_path)
                             # if cloned succesfully, exit the while block
                             cloned = True
                         except git.exc.GitCommandError as e:
@@ -57,6 +57,10 @@ class GitProject:
             if cloned == False:
                 # if none of the URIs worked, raise runtime error
                 raise RuntimeError(f"Failed cloning repo from: {self.url}. Failed with error: {e}")
+                
+    @staticmethod
+    def _clone_repo(url, dest, branch='master', depth=1):
+        git.Repo.clone_from(url, dest)
                 
                     
     def _find_git_uri(self, repo_url):

--- a/src/git.py
+++ b/src/git.py
@@ -1,6 +1,6 @@
 import sys
 from datetime import datetime, timedelta
-from collections import namedtuple
+from dataclasses import dataclass
 import json
 import re
 from pathlib import Path
@@ -12,8 +12,10 @@ from src.config import Config
 
 logger = Config.getLogger("git")
 
-
-GitProjectGlob = namedtuple("GitProjectGlob", ["name", "glob"])
+@dataclass
+class GitProjectGlob:
+    name: str
+    glob: typing.List[str]
 
 class GitProject:
     """A project made available via git

--- a/src/library/package_info.py
+++ b/src/library/package_info.py
@@ -1,7 +1,8 @@
 """The package class defining a python module, application or library
 """
+from dataclasses import dataclass 
 
+@dataclass
 class PackageInfo:
-    def __init__(self,  name: str,  repo_url: str):
-        self.name = name
-        self.repo_url = repo_url
+    name: str
+    repo_url: str

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,0 +1,24 @@
+import pytest
+import tempfile
+from pathlib import Path
+from src import git
+
+@pytest.fixture()
+def git_project():
+    name = "solfege"
+    url = "http://git.savannah.gnu.org/cgit/solfege.git"
+    tmpdir = tempfile.TemporaryDirectory()
+    dest_dir = Path(tmpdir.name) / name 
+    project = git.GitProject(name, url, no_fetch=True)
+    project.dest_path = dest_dir
+    yield project
+    
+def test_find_git_uri(git_project):
+    """Tests the regex functionality in finding git uris from an invalid 
+    git repo link. 
+    
+    TODO: convert to sample data/mocked url, currently making live request to git.savannah.gnu.org
+    """
+    uris = git_project._find_git_uri(git_project.url)
+    uri_list = list(uris)
+    assert len(uri_list) == 1


### PR DESCRIPTION
* if cloning via repo_url fails, find git URIs in the page

*update*
after @mahmoud review: 
* namedtuple -> dataclasses
  * includes 3.6.4 -> 3.7.1 migration
* shallow git clone (depth=1)